### PR TITLE
Catch DNS timeout introduced at async/await rewrite

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+## 2.0.2 - 2022-10-21
+
+- fix: catching DNS timeout exception
 
 ## 2.0.1 - 2022-05-27
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ exports.load_asn_ini = function () {
 
 exports.get_dns_results = async function (zone, ip) {
   const query = `${ip.split('.').reverse().join('.')}.${zone}`;
-.
+
   const timeout = (prom, time, exception) => {
     let timer;
     return Promise.race([

--- a/index.js
+++ b/index.js
@@ -87,8 +87,8 @@ exports.get_dns_results = async function (zone, ip) {
   const timeout = (prom, time, exception) => {
     let timer;
     return Promise.race([
-        prom,
-        new Promise((_r, rej) => timer = setTimeout(rej, time, exception))
+      prom,
+      new Promise((_r, rej) => timer = setTimeout(rej, time, exception))
     ]).finally(() => clearTimeout(timer));
   }
 
@@ -107,9 +107,8 @@ exports.get_dns_results = async function (zone, ip) {
     const first = addrs[0];
 
     this.logdebug(this, `${zone} answers: ${first}`);
-    const result = this.get_result(zone, first);
-
-    return result
+    
+    return this.get_result(zone, first);
   }
   catch (err) {
     this.logerror(this, `error: ${err} running: ${query}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-asn",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "look up ASN of remote MTA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Error thrown by setTimeout is not catched anywhere and thus killing server.

See commit for details